### PR TITLE
Add crises page and UI

### DIFF
--- a/app/app/(tabs)/crises.tsx
+++ b/app/app/(tabs)/crises.tsx
@@ -1,18 +1,85 @@
+import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
 import React = require("react");
-import { View, Text, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+  Pressable,
+} from "react-native";
+import CrisisCard from "@/app/components/Crises/CrisisCard";
+import NewCrisisModal from "@/app/components/Crises/NewCrisisModal";
 
 export default function CrisesScreen() {
+  const [modalVisible, setModalVisible] = React.useState(false);
   return (
-    <View style={styles.container}>
-      <Text>Crisis</Text>
-    </View>
+    <SafeAreaView
+      style={{
+        flex: 1,
+        backgroundColor: "#fff",
+      }}
+    >
+      <NewCrisisModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+      />
+      <ScrollView className="p-8 bg-white">
+        <View className="flex-row items-center justify-between mb-4">
+          <Text className="text-4xl text-primary font-bold">My crises</Text>
+          <Pressable
+            onPress={() => setModalVisible(true)}
+            hitSlop={10}
+            className="bg-primary text-white w-1/4 rounded-lg py-2 px-6 mt-2"
+          >
+            <Text className="text-white font-bold text-center">
+              <FontAwesome5 name="plus" size={24} color="white" />
+            </Text>
+          </Pressable>
+        </View>
+        <View>
+          <Text className="text-2xl text-primary mb-2">June 2025</Text>
+          <CrisisCard
+            info={{
+              name: "Cold",
+              comments:
+                "I went outside when I was raining and forgot to wear an umbrella",
+              startDate: "Monday, June 9",
+              endDate: "Friday, June 13",
+            }}
+          ></CrisisCard>
+          <CrisisCard
+            info={{
+              name: "Cold",
+              comments:
+                "I went outside when I was raining and forgot to wear an umbrella",
+              startDate: "Monday, June 9",
+              endDate: "Friday, June 13",
+            }}
+          ></CrisisCard>
+        </View>
+        <View>
+          <Text className="text-2xl text-primary mb-2">May 2025</Text>
+          <CrisisCard
+            info={{
+              name: "Cold",
+              comments:
+                "I went outside when I was raining and forgot to wear an umbrella",
+              startDate: "Monday, May 9",
+              endDate: "Friday, May 13",
+            }}
+          ></CrisisCard>
+          <CrisisCard
+            info={{
+              name: "Cold",
+              comments:
+                "I went outside when I was raining and forgot to wear an umbrella",
+              startDate: "Monday, May 9",
+              endDate: "Friday, May 13",
+            }}
+          ></CrisisCard>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-});

--- a/app/app/components/Crises/CrisisCard.tsx
+++ b/app/app/components/Crises/CrisisCard.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { Text, View, TouchableOpacity } from "react-native";
+
+type CrisisCardProps = {
+  squareColor?: string;
+  info: {
+    [key: string]: any;
+  };
+};
+
+const CrisisCard: React.FC<CrisisCardProps> = ({
+  squareColor = "bg-blue-100",
+  info,
+}: CrisisCardProps) => (
+  <TouchableOpacity
+    className={`h-60 rounded-xl items-center justify-center m-2 ${squareColor}`}
+  >
+    <View className="items-start p-8">
+      <Text className="text-base text-primary font-bold">{info.name}</Text>
+      <Text className="text-base text-primary">
+        {info.startDate} - {info.endDate}
+      </Text>
+      <Text className="text-base text-primary underline">Notes:</Text>
+      <Text className="text-base text-primary pl-4">{info.comments}</Text>
+    </View>
+  </TouchableOpacity>
+);
+
+export default CrisisCard;


### PR DESCRIPTION
This pull request introduces a new user interface for managing crises, including a redesigned `CrisesScreen` with enhanced functionality and a new reusable `CrisisCard` component. The changes focus on improving the user experience by adding interactivity and better visual organization.

### Updates to `CrisesScreen`:

* Replaced the basic `View` layout with a `SafeAreaView` and `ScrollView` to enable scrolling and ensure proper layout on all devices.
* Added a "New Crisis" button using `Pressable` and integrated a `NewCrisisModal` component for adding new crises.
* Displayed crises grouped by month (`June 2025` and `May 2025`) with a title and corresponding `CrisisCard` components for each crisis.

### Introduction of `CrisisCard` component:

* Created a reusable `CrisisCard` component to display crisis details such as name, dates, and comments.
* Added customizable `squareColor` property for styling and ensured the component is touch-enabled with `TouchableOpacity`.