### PR TITLE
Add exams page and UI

### DIFF
--- a/app/app/(tabs)/exams.tsx
+++ b/app/app/(tabs)/exams.tsx
@@ -1,18 +1,81 @@
+import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
 import React = require("react");
-import { View, Text, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+  Pressable,
+} from "react-native";
+import ExamCard from "@/app/components/Exams/ExamCard";
+import NewExamModal from "@/app/components/Exams/NewExamModal";
 
 export default function ExamsScreen() {
+  const [modalVisible, setModalVisible] = React.useState(false);
   return (
-    <View style={styles.container}>
-      <Text>Exams</Text>
-    </View>
+    <SafeAreaView
+      style={{
+        flex: 1,
+        backgroundColor: "#fff",
+      }}
+    >
+      <NewExamModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+      />
+      <ScrollView className="p-8 bg-white">
+        <View className="flex-row items-center justify-between mb-4">
+          <Text className="text-4xl text-primary font-bold">My exams</Text>
+          <Pressable
+            onPress={() => setModalVisible(true)}
+            hitSlop={10}
+            className="bg-primary text-white w-1/4 rounded-lg py-2 px-6 mt-2"
+          >
+            <Text className="text-white font-bold text-center">
+              <FontAwesome5 name="plus" size={24} color="white" />
+            </Text>
+          </Pressable>
+        </View>
+        <View>
+          <Text className="text-2xl text-primary mb-2">June 2025</Text>
+          <ExamCard
+            info={{
+              name: "Complete Blood Count",
+              ai_summary:
+                "Your iron levels are low—consider dietary changes or supplements",
+              date: "Monday, June 9",
+            }}
+          ></ExamCard>
+          <ExamCard
+            info={{
+              name: "Complete Blood Count",
+              ai_summary:
+                "Your iron levels are low—consider dietary changes or supplements",
+              date: "Monday, June 9",
+            }}
+          ></ExamCard>
+        </View>
+        <View>
+          <Text className="text-2xl text-primary mb-2">May 2025</Text>
+          <ExamCard
+            info={{
+              name: "Complete Blood Count",
+              ai_summary:
+                "Your iron levels are low—consider dietary changes or supplements",
+              date: "Monday, June 9",
+            }}
+          ></ExamCard>
+          <ExamCard
+            info={{
+              name: "Complete Blood Count",
+              ai_summary:
+                "Your iron levels are low—consider dietary changes or supplements",
+              date: "Monday, June 9",
+            }}
+          ></ExamCard>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-});

--- a/app/app/components/Exams/ExamCard.tsx
+++ b/app/app/components/Exams/ExamCard.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { Text, View, TouchableOpacity } from "react-native";
+import ExamInfoModal from "./ExamInfoModal";
+
+type ExamCardProps = {
+  squareColor?: string;
+  info: {
+    [key: string]: any;
+  };
+};
+
+const ExamCard: React.FC<ExamCardProps> = ({
+  squareColor = "bg-blue-100",
+  info,
+}: ExamCardProps) => {
+  const [modalVisible, setModalVisible] = React.useState(false);
+
+  return (
+    <>
+      <TouchableOpacity
+        className={`h-30 rounded-xl m-2 ${squareColor}`}
+        onPress={() => setModalVisible(true)}
+      >
+        <View className="items-start p-5">
+          <Text className="text-base text-primary font-bold">{info.name}</Text>
+          <Text className="text-base text-primary">{info.date}</Text>
+        </View>
+      </TouchableOpacity>
+      <ExamInfoModal
+        visible={modalVisible}
+        info={info}
+        onClose={() => setModalVisible(false)}
+      />
+    </>
+  );
+};
+
+export default ExamCard;

--- a/app/app/components/Exams/ExamInfoModal.tsx
+++ b/app/app/components/Exams/ExamInfoModal.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { Text, View, Modal, Pressable } from "react-native";
+import { BlurView } from "expo-blur";
+
+type ExamInfoModalProps = {
+  visible: boolean;
+  info: {
+    [key: string]: any;
+  };
+  onClose: () => void;
+};
+
+const ExamInfoModal: React.FC<ExamInfoModalProps> = ({
+  visible,
+  info,
+  onClose,
+}) => {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1">
+        <BlurView intensity={20} tint="prominent" className="flex-1">
+          <View className="flex-1 items-center justify-center">
+            <View className="bg-white rounded-2xl p-6 w-11/12 max-w-md">
+              <View className="flex-row items-center justify-between mb-4">
+                <Text className="text-2xl text-primary font-bold">
+                  {info.name}
+                </Text>
+                <Pressable
+                  onPress={() => {
+                    onClose();
+                  }}
+                  hitSlop={10}
+                  className="ml-2"
+                >
+                  <Text className="text-2xl text-primary font-bold">×</Text>
+                </Pressable>
+              </View>
+              <View>
+                <Text className="text-xl">{info.date}</Text>
+              </View>
+              <View>
+                <Text>File goes here</Text>
+              </View>
+              <View>
+                <Text className="text-xl mt-4 underline">AI summary</Text>
+                <Text className="text-muted italic">
+                  AI responses are not always accurate.
+                </Text>
+                <Text className="mt-4 pl-4">
+                  {info.ai_summary || "No AI summary available."}
+                </Text>
+              </View>
+            </View>
+          </View>
+        </BlurView>
+      </View>
+    </Modal>
+  );
+};
+
+export default ExamInfoModal;


### PR DESCRIPTION
This pull request introduces a new feature for managing and displaying exam-related information in the app. It includes the creation of several new components (`ExamCard`, `ExamInfoModal`, and `NewExamModal`) and a significant redesign of the `ExamsScreen` to support the new functionality. The changes enhance the user experience by adding modals, interactive elements, and improved styling.

### New Components and Features:

* **`ExamCard` Component**: A reusable card component displaying basic exam information (name and date). It opens a detailed view in a modal (`ExamInfoModal`) when pressed.
* **`ExamInfoModal` Component**: A modal providing detailed information about an exam, including AI-generated summaries and additional metadata. It uses a `BlurView` for background styling.

### `ExamsScreen` Redesign:

* **UI Overhaul**: Replaced the static layout with a scrollable, styled interface using `SafeAreaView` and `ScrollView`. Added a "My exams" section with categorized exam cards (by month).
* **New Exam Modal**: Integrated a `NewExamModal` component for adding new exams, triggered by a "+" button in the header.

These changes collectively improve the app's usability and visual appeal while introducing modular components for easier maintenance and scalability.