### PR TITLE
Fix padding bottom to not crop content with bottom bar

### DIFF
--- a/app/app/(tabs)/crises.tsx
+++ b/app/app/(tabs)/crises.tsx
@@ -24,7 +24,10 @@ export default function CrisesScreen() {
         visible={modalVisible}
         onClose={() => setModalVisible(false)}
       />
-      <ScrollView className="p-8 bg-white">
+      <ScrollView
+        className="p-8 bg-white"
+        contentContainerStyle={{ paddingBottom: 80 }}
+      >
         <View className="flex-row items-center justify-between mb-4">
           <Text className="text-4xl text-primary font-bold">My crises</Text>
           <Pressable

--- a/app/app/(tabs)/exams.tsx
+++ b/app/app/(tabs)/exams.tsx
@@ -24,7 +24,10 @@ export default function ExamsScreen() {
         visible={modalVisible}
         onClose={() => setModalVisible(false)}
       />
-      <ScrollView className="p-8 bg-white">
+      <ScrollView
+        className="p-8 bg-white"
+        contentContainerStyle={{ paddingBottom: 80 }}
+      >
         <View className="flex-row items-center justify-between mb-4">
           <Text className="text-4xl text-primary font-bold">My exams</Text>
           <Pressable

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -19,7 +19,10 @@ export default function HomeScreen() {
         backgroundColor: "#fff",
       }}
     >
-      <ScrollView className="p-8 bg-white">
+      <ScrollView
+        className="p-8 bg-white"
+        contentContainerStyle={{ paddingBottom: 80 }}
+      >
         <View>
           <Text className="text-5xl text-primary">Welcome back,</Text>
           <Text className="text-5xl font-bold text-primary">Miguel</Text>


### PR DESCRIPTION
This pull request makes a consistent enhancement to the `ScrollView` components across multiple screens by adding a `contentContainerStyle` property to ensure proper padding at the bottom. This improves the UI/UX by preventing content from being cut off or inaccessible, especially when using scrollable views.

### UI Enhancements:

* [`app/app/(tabs)/crises.tsx`](diffhunk://#diff-7c9cb972b7b1ea0f5b9b2bc1d9aefbf2699696bcca6564a122512d1c3d7eac4cL27-R30): Updated the `ScrollView` in the `CrisesScreen` component to include a `contentContainerStyle` with `paddingBottom: 80`.
* [`app/app/(tabs)/exams.tsx`](diffhunk://#diff-d6fefe6973b2607a59d8f7df655bb2bd49481fc83b06dee03aead4bea2440124L27-R30): Updated the `ScrollView` in the `ExamsScreen` component to include a `contentContainerStyle` with `paddingBottom: 80`.
* [`app/app/(tabs)/index.tsx`](diffhunk://#diff-109a76737f6192f0cfc78175f215da4f5362763fdefb9f125e19ea659c89ec62L22-R25): Updated the `ScrollView` in the `HomeScreen` component to include a `contentContainerStyle` with `paddingBottom: 80`.