### PR TITLE
Implement connection with RAG

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -5,6 +5,7 @@ from .serializers import ExamSerializer
 from django.conf import settings
 import os
 from rest_framework.permissions import IsAuthenticated
+import requests
 
 class ExamViewSet(viewsets.ModelViewSet):
     queryset = Exam.objects.all()
@@ -44,8 +45,28 @@ class ExamViewSet(viewsets.ModelViewSet):
 
         # Only generate ai_summary if requested
         if analyze_with_ai:
-            exam.ai_summary = "AI summary generated here."
+            exam.ai_summary = self.get_ai_summary(file_path)
 
         exam.save()
         response_serializer = self.get_serializer(exam)
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+    
+    def get_ai_summary(self, file_path):
+        url = "http://localhost:8001/ask"  # Update if your RAG service runs elsewhere
+        question = (
+            "Based on the provided, please explain the results in simple terms and offer clear recommendations. "
+            "Only use the available information; do not ask for additional details, and be concise not more than 20 words to respond."
+        )
+        try:
+            with open(file_path, "rb") as f:
+                files = {"pdf": (os.path.basename(file_path), f, "application/pdf")}
+                data = {"question": question, "save": "false"}
+                response = requests.post(url, files=files, data=data)
+                if response.status_code == 200:
+                    result = response.json()
+                    # If result is a dict with 'answer' or similar, adjust as needed
+                    return result.get("answer") or result.get("summary") or str(result)
+                else:
+                    return f"AI summary error: {response.text}"
+        except Exception as e:
+            return f"AI summary error: {str(e)}"

--- a/rag_groq/.gitignore
+++ b/rag_groq/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/


### PR DESCRIPTION
This pull request introduces a new feature for generating AI-based summaries of exam results in the `ExamViewSet` and includes minor housekeeping changes. The most important updates involve adding a method to interact with an external RAG service for AI summaries and updating the `.gitignore` file.

### Feature: AI-based summaries for exams
* [`backend/exams/views.py`](diffhunk://#diff-be661d3aac93db7efefb405badce85b1a3071c10b8b0f5db04d898454166a7cbR8): Added a `get_ai_summary` method to interact with an external RAG service for generating AI summaries. This method sends a POST request with a PDF file and a predefined question to the RAG service and processes the response. The `create` method now uses this new function to generate the AI summary when requested. [[1]](diffhunk://#diff-be661d3aac93db7efefb405badce85b1a3071c10b8b0f5db04d898454166a7cbR8) [[2]](diffhunk://#diff-be661d3aac93db7efefb405badce85b1a3071c10b8b0f5db04d898454166a7cbL47-R72)

### Housekeeping
* [`rag_groq/.gitignore`](diffhunk://#diff-792c02932ea144c5e21e7581ea2102e3b025225b5c16276459e4bbbbbaf8328bR1-R2): Updated to ignore `.env` files and `__pycache__/` directories, ensuring sensitive information and unnecessary files are not tracked.